### PR TITLE
Update version bem-tools-create to ^2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "bem-tools-core": "^0.0.3",
-    "bem-tools-create": "^2.0.0"
+    "bem-tools-create": "^2"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
```
npm i --save-dev bem
npm WARN deprecated bem-fs-scheme@1.0.0: Use @bem/fs-scheme instead
npm WARN bem-project-stub@2.0.0 No license field.

+ bem@2.0.0
npm ls --dept 1
bem-project-stub@2.0.0 /home/ilyar/prj/bem-bootstrap
└─┬ bem@2.0.0
  ├── bem-tools-core@0.0.3
  └── bem-tools-create@1.1.0
```
vs
```
npm i ilyar/bem-tools
+ bem@2.0.0
npm ls --dept 1
bem-project-stub@2.0.0 /home/ilyar/prj/bem-bootstrap
└─┬ bem@2.0.0 (github:ilyar/bem-tools#35b881a199307d5db3153737f670d76bd1313fff)
  ├── bem-tools-core@0.0.3
  └── bem-tools-create@2.2.0

```